### PR TITLE
fixes for send rdmpacket 

### DIFF
--- a/ArtNet/ArtNet/Sockets/ArtNetSocket.cs
+++ b/ArtNet/ArtNet/Sockets/ArtNetSocket.cs
@@ -191,7 +191,8 @@ namespace Haukcode.ArtNet.Sockets
 
                 //Create sACN Packet
                 var rdmPacket = new ArtRdmPacket();
-                rdmPacket.Address = (byte)targetAddress.Universe;
+                rdmPacket.Address = (byte)(targetAddress.Universe & 0x00FF);
+                rdmPacket.Net = (byte)(targetAddress.Universe >> 8); 
                 rdmPacket.SubStartCode = (byte)RdmVersions.SubMessage;
                 rdmPacket.RdmData = rdmData.GetBuffer();
 

--- a/ArtNet/ArtNet/Sockets/ArtNetSocket.cs
+++ b/ArtNet/ArtNet/Sockets/ArtNetSocket.cs
@@ -194,7 +194,7 @@ namespace Haukcode.ArtNet.Sockets
                 rdmPacket.Address = (byte)(targetAddress.Universe & 0x00FF);
                 rdmPacket.Net = (byte)(targetAddress.Universe >> 8); 
                 rdmPacket.SubStartCode = (byte)RdmVersions.SubMessage;
-                rdmPacket.RdmData = rdmData.GetBuffer();
+                rdmPacket.RdmData = rdmData.ToArray();
 
                 Send(rdmPacket, targetAddress);
 

--- a/ArtNet/Sockets/RdmEndPoint.cs
+++ b/ArtNet/Sockets/RdmEndPoint.cs
@@ -56,9 +56,9 @@ namespace Haukcode.Sockets
             set { gatewayId = value; }
         }
 
-        private int universe = 0;
+        private ushort universe = 0;
 
-        public int Universe
+        public ushort Universe
         {
             get { return universe; }
             set { universe = value; }


### PR DESCRIPTION
this PR fixes bugs:
1. non correct Net parameter (for universes greater then 255)
2. rdmpacket oversize (not less 256byte) due to MemoryStream.getBuffer() nature (see remarks https://learn.microsoft.com/en-us/dotnet/api/system.io.memorystream.getbuffer?view=net-8.0)